### PR TITLE
Install node-fetch in bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "rttr_layouts",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "node-fetch": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -60,17 +60,20 @@
                 "height": 1080
             }
         ],
-		"assetCategories": [
-			{
-				"name": "runnerIcon",
-				"title": "走者アイコン",
-				"allowedTypes": ["jpg", "jpeg", "gif", "png"]
+        "assetCategories": [
+            {
+                "name": "runnerIcon",
+                "title": "走者アイコン",
+                "allowedTypes": ["jpg", "jpeg", "gif", "png"]
             },
             {
                 "name": "materials",
                 "title": "レイアウト用素材",
                 "allowedTypes": ["png"]
             }
-		]
+        ]
+    },
+    "dependencies": {
+        "node-fetch": "^2.6.1"
     }
 }


### PR DESCRIPTION
起動時に下記エラーが発生したので、このプロジェクトの依存性として `node-fetch` を追加しました
```
error: [rttr_layouts] Failed to initialize:
{
  message: "Cannot find module 'node-fetch'\n" +
    'Require stack:\n' +
    '- /home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/infoKeeping.js\n' +
    '- /home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/index.js\n' +
    '- /home/potdig/nodejs/nodecg/lib/server/extensions.js\n' +
    '- /home/potdig/nodejs/nodecg/lib/server/index.js\n' +
    '- /home/potdig/nodejs/nodecg/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/commands/start.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/commands/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/bin/nodecg.js',
  stack: "Error: Cannot find module 'node-fetch'\n" +
    'Require stack:\n' +
    '- /home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/infoKeeping.js\n' +
    '- /home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/index.js\n' +
    '- /home/potdig/nodejs/nodecg/lib/server/extensions.js\n' +
    '- /home/potdig/nodejs/nodecg/lib/server/index.js\n' +
    '- /home/potdig/nodejs/nodecg/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/commands/start.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/commands/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/index.js\n' +
    '- /usr/local/lib/node_modules/nodecg-cli/dist/bin/nodecg.js\n' +
    '    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:957:15)\n' +
    '    at Function.Module._load (internal/modules/cjs/loader.js:840:27)\n' +
    '    at Module.require (internal/modules/cjs/loader.js:1019:19)\n' +
    '    at require (internal/modules/cjs/helpers.js:77:18)\n' +
    '    at Object.<anonymous> (/home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/infoKeeping.js:3:15)\n' +
    '    at Module._compile (internal/modules/cjs/loader.js:1133:30)\n' +
    '    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)\n' +
    '    at Module.load (internal/modules/cjs/loader.js:977:32)\n' +
    '    at Function.Module._load (internal/modules/cjs/loader.js:877:14)\n' +
    '    at Module.require (internal/modules/cjs/loader.js:1019:19)\n' +
    '    at require (internal/modules/cjs/helpers.js:77:18)\n' +
    '    at init (/home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/index.js:16:5)\n' +
    '    at module.exports (/home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/index.js:8:5)\n' +
    '    at _loadExtension (/home/potdig/nodejs/nodecg/lib/server/extensions.js:103:37)\n' +
    '    at EventEmitter.module.exports.init (/home/potdig/nodejs/nodecg/lib/server/extensions.js:32:6)\n' +
    '    at EventEmitter.module.exports.start (/home/potdig/nodejs/nodecg/lib/server/index.js:310:19)\n' +
    '    at Object.<anonymous> (/home/potdig/nodejs/nodecg/index.js:77:8)\n' +
    '    at Module._compile (internal/modules/cjs/loader.js:1133:30)\n' +
    '    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)\n' +
    '    at Module.load (internal/modules/cjs/loader.js:977:32)\n' +
    '    at Function.Module._load (internal/modules/cjs/loader.js:877:14)\n' +
    '    at Module.require (internal/modules/cjs/loader.js:1019:19)\n' +
    '    at require (internal/modules/cjs/helpers.js:77:18)\n' +
    '    at Command.<anonymous> (/usr/local/lib/node_modules/nodecg-cli/dist/commands/start.js:11:13)\n' +
    '    at Command.listener (/usr/local/lib/node_modules/nodecg-cli/node_modules/commander/index.js:315:8)\n' +
    '    at Command.emit (events.js:310:20)\n' +
    '    at Command.parseArgs (/usr/local/lib/node_modules/nodecg-cli/node_modules/commander/index.js:651:12)\n' +
    '    at Command.parse (/usr/local/lib/node_modules/nodecg-cli/node_modules/commander/index.js:474:21)\n' +
    '    at Object.<anonymous> (/usr/local/lib/node_modules/nodecg-cli/dist/index.js:37:9)\n' +
    '    at Module._compile (internal/modules/cjs/loader.js:1133:30)\n' +
    '    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)\n' +
    '    at Module.load (internal/modules/cjs/loader.js:977:32)\n' +
    '    at Function.Module._load (internal/modules/cjs/loader.js:877:14)\n' +
    '    at Module.require (internal/modules/cjs/loader.js:1019:19)\n' +
    '    at require (internal/modules/cjs/helpers.js:77:18)\n' +
    '    at Object.<anonymous> (/usr/local/lib/node_modules/nodecg-cli/dist/bin/nodecg.js:22:1)\n' +
    '    at Module._compile (internal/modules/cjs/loader.js:1133:30)\n' +
    '    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)\n' +
    '    at Module.load (internal/modules/cjs/loader.js:977:32)\n' +
    '    at Function.Module._load (internal/modules/cjs/loader.js:877:14)\n' +
    '    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)\n' +
    '    at internal/main/run_main_module.js:18:47',
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/infoKeeping.js',
    '/home/potdig/nodejs/nodecg/bundles/rttr_layouts/extension/index.js',
    '/home/potdig/nodejs/nodecg/lib/server/extensions.js',
    '/home/potdig/nodejs/nodecg/lib/server/index.js',
    '/home/potdig/nodejs/nodecg/index.js',
    '/usr/local/lib/node_modules/nodecg-cli/dist/commands/start.js',
    '/usr/local/lib/node_modules/nodecg-cli/dist/commands/index.js',
    '/usr/local/lib/node_modules/nodecg-cli/dist/index.js',
    '/usr/local/lib/node_modules/nodecg-cli/dist/bin/nodecg.js'
  ]
}
```